### PR TITLE
Gerar Overlay e Collection para Seriados Cancelado

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,30 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - desenvolvimento  # Define a branch que irá disparar o workflow
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.joaopaulofvaz }}/tssk:desenvolvimento # Ajuste aqui

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,4 +27,4 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.joaopaulofvaz }}/tssk:desenvolvimento # Ajuste aqui
+          tags: ${{ secrets.DOCKER_USERNAME }}/tssk:desenvolvimento # Ajuste aqui

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,11 +3,12 @@ name: Build and Push Docker Image
 on:
   push:
     branches:
-      - desenvolvimento  # Define a branch que irá disparar o workflow
+      - desenvolvimento
 
 jobs:
   build_and_push:
     runs-on: ubuntu-latest
+    if: contains(github.event.head_commit.message, 'docker.run')
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -27,4 +28,4 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/tssk:desenvolvimento # Ajuste aqui
+          tags: ${{ secrets.DOCKER_USERNAME }}/tssk:desenvolvimento

--- a/README.md
+++ b/README.md
@@ -186,7 +186,9 @@ TV Shows:
 
 > [!TIP]
 > Adicione apenas os arquivos para as catégorias que você quiser ativar. Todas são opcionais e geradas de forma independente baseado no seus arquivos de configuração.
+> 
 > Os arquivos de Overlay oferecem melhor aproveitamento se forem aplicados na sequência numérica de acordo com o numero informado no nome do arquivo.
+> 
 > Ativar as generate_all_in_one_overlays,  delete_overlay_after_all_in_one, generate_all_in_one_collections e delete_collections_after_all_in_one dirá ao script para concatenar todos os arquivos em um só, podendo este ser aplicado de uma única vez no Kometa.
 
 ### 2️⃣ Edite seu arquivos de Configuração

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Este é um fork de https://github.com/netplexflix/TV-show-status-for-Kometa, tod
 * Script ajustado para caracteres pt-BR;
 * Corrigido o fato do script não salvar os arquivos na pasta do Kometa quando executando em Docker;
 * Inseridos alguns scripts para filtros de situações no passado vindo do Plex.
+* A possibilidade de ativar a opção para que todos os scritps sejam salvos em um único arquivo, economizando tempo de configuração.
 * Script Traduzido para pt-BR.
 
 # 📺 Status dos Seriados para Kometa
@@ -34,10 +35,9 @@ Categorias Plex:
     * Overlay no episódio adicionado dentro de X dias passados
     * Overlay no episódio novo adicionado dentro de X dias passados
    
-A diferença entre item novo e item adicionado é a idade, pois novo se refere ao que foi ao ar recentemente, e adicionado independe de idade.
-
-
-  
+>[!TIP]
+>A diferença entre item novo e item adicionado é a idade, pois novo se refere ao que foi ao ar recentemente, e adicionado independe de idade.
+---  
 Exemplo de Overlay (você pode customizar complemente a localização, cor textos e etc):
 
 ![Image](https://github.com/user-attachments/assets/caccb1c7-4799-4b41-b133-8ae128e20a50)
@@ -187,6 +187,7 @@ TV Shows:
 > [!TIP]
 > Adicione apenas os arquivos para as catégorias que você quiser ativar. Todas são opcionais e geradas de forma independente baseado no seus arquivos de configuração.
 > Os arquivos de Overlay oferecem melhor aproveitamento se forem aplicados na sequência numérica de acordo com o numero informado no nome do arquivo.
+> Ativar as generate_all_in_one_overlays,  delete_overlay_after_all_in_one, generate_all_in_one_collections e delete_collections_after_all_in_one dirá ao script para concatenar todos os arquivos em um só, podendo este ser aplicado de uma única vez no Kometa.
 
 ### 2️⃣ Edite seu arquivos de Configuração
 ---

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ TV Shows:
 > 
 > Os arquivos de Overlay oferecem melhor aproveitamento se forem aplicados na sequência numérica de acordo com o numero informado no nome do arquivo.
 > 
-> Ativar as generate_all_in_one_overlays,  delete_overlay_after_all_in_one, generate_all_in_one_collections e delete_collections_after_all_in_one dirá ao script para concatenar todos os arquivos em um só, podendo este ser aplicado de uma única vez no Kometa.
+> Ativar as opções generate_all_in_one_overlays,  delete_overlay_after_all_in_one, generate_all_in_one_collections e delete_collections_after_all_in_one dirá ao script para concatenar todos os arquivos em um só, podendo este ser aplicado de uma única vez no Kometa.
 
 ### 2️⃣ Edite seu arquivos de Configuração
 ---

--- a/TSSK.py
+++ b/TSSK.py
@@ -137,7 +137,7 @@ def get_tmdb_status(tvdb_id, tmdb_api_key):
     try:
         # First call to find the TMDB id from the TVDB id
         find_url = (
-            f"https://api.themoviedb.org/3/find/{tvdb_id}?api_key="
+            f"http://api.themoviedb.org/3/find/{tvdb_id}?api_key="
             f"{tmdb_api_key}&external_source=tvdb_id"
         )
         resp = requests.get(find_url, timeout=10)
@@ -150,7 +150,7 @@ def get_tmdb_status(tvdb_id, tmdb_api_key):
         if not tmdb_id:
             return None
 
-        details_url = f"https://api.themoviedb.org/3/tv/{tmdb_id}?api_key={tmdb_api_key}"
+        details_url = f"http://api.themoviedb.org/3/tv/{tmdb_id}?api_key={tmdb_api_key}"
         resp = requests.get(details_url, timeout=10)
         resp.raise_for_status()
         info = resp.json()
@@ -1510,7 +1510,7 @@ def concatenate_overlays(is_docker, overlay_path="",delete_overlay_after_all_in_
         is_docker (bool): Indica se o script está sendo executado em um ambiente Docker.
         overlay_path (str): O caminho do diretório dos overlays se estiver no Docker.
     """
-    print(f"{AZUL}Iniciando a concatenação dos arquivos de overlays...{RESET}")
+    print(f"\n{AZUL}Iniciando a concatenação dos arquivos de overlays...{RESET}")
     output_file_name = "TSSK_TV_ALL_OVERLAYS_TOGETHER.yml" #Não pode terminar com OVERLAY.yml para evitar loop infito das informações.
     
     # Define o diretório de busca com base em IS_DOCKER
@@ -1543,15 +1543,12 @@ def concatenate_overlays(is_docker, overlay_path="",delete_overlay_after_all_in_
                         
                         # Substitui 'backdrop:' por 'backdropX:'
                         if "backdrop:" in line:
-                            modified_line = line.replace("backdrop:", f"backdrop{line_count}:")
-                            outfile.write(modified_line)
-                        else:
-                            outfile.write(line)
-                            
-                        # Substitui 'TSSK:' por 'TSSKX:'
-                        if "TSSK" in line:
-                            modified_line = line.replace("TSSK", f"TSSK{line_count}{line[-10:]}")
-                            outfile.write(modified_line)
+                            backdrop_line = line.replace("backdrop:", f"backdrop{line_count}:")
+                            outfile.write(backdrop_line)
+                        elif "TSSK" in line:
+                            TSSK_line = line.replace("TSSK", f"TSSK{line_count}")
+                            outfile.write(TSSK_line)
+                        
                         else:
                             outfile.write(line)
                             
@@ -1564,7 +1561,7 @@ def concatenate_overlays(is_docker, overlay_path="",delete_overlay_after_all_in_
             
             line_count += 1
             
-    print(f"\n{VERDE}Todos os arquivos foram combinados em {output_file_name} com sucesso!{RESET}")
+    print(f"Todos os arquivos foram combinados em {output_file_name} com sucesso!{RESET}\n")
     
     #Deleta os arquivos originais se true no arquivo de configuração
     if delete_overlay_after_all_in_one and generate_all_in_one_overlays:
@@ -1740,7 +1737,7 @@ def concatenate_collections(is_docker, collection_path="",delete_collections_aft
         is_docker (bool): Indica se o script está sendo executado em um ambiente Docker.
         collection_path (str): O caminho do diretório dos collection se estiver no Docker.
     """
-    print(f"{AZUL}Iniciando a concatenação dos arquivos de coleção...{RESET}")
+    print(f"\n{AZUL}Iniciando a concatenação dos arquivos de coleção...{RESET}")
     output_file_name = "TSSK_ALL_COLLECTIONS_TOGETHER.yml" #Não pode terminar com collection.yml para evitar loop infito das informações.
     
     # Define o diretório de busca com base em IS_DOCKER
@@ -1769,7 +1766,7 @@ def concatenate_collections(is_docker, collection_path="",delete_collections_aft
                     for i, line in enumerate(lines):
                         if i == 0:
                             continue  # Pula a primeira linha
-                        
+                        else:
                             outfile.write(line) # Copia linhas seguintes para o arquivo. 
                             
             except FileNotFoundError:
@@ -1779,7 +1776,7 @@ def concatenate_collections(is_docker, collection_path="",delete_collections_aft
                 print(f"{VERMELHO}Erro ao processar o arquivo {file_path}: {e}{RESET}")
                 continue
           
-    print(f"\n{VERDE}Todos os arquivos foram combinados em {output_file_name} com sucesso!{RESET}")
+    print(f"Todos os arquivos foram combinados em {output_file_name} com sucesso!{RESET}\n")
     
     #Deleta os arquivos originais se true no arquivo de configuração
     if delete_collections_after_all_in_one and generate_all_in_one_collections:
@@ -2212,10 +2209,10 @@ def main():
             sonarr_url, sonarr_api_key, future_days_upcoming_finale, utc_offset, skip_unmonitored
         )
         
-        # Filter out shows that are in the season finale or final episode categories
+        # Filtrar os programas que estão no final da temporada ou em categorias de episódios finais
         finale_eps = [show for show in finale_eps if show.get('tvdbId') not in all_excluded_tvdb_ids]
         
-        # Add to excluded IDs for returning category
+        # Adicionar aos IDs excluídos para a categoria de retorno
         for show in finale_eps:
             if show.get('tvdbId'):
                 all_included_tvdb_ids.add(show['tvdbId'])
@@ -2248,12 +2245,12 @@ def main():
                 print(f"- {show['title']} (Temporada {show['seasonNumber']}) vai ao ar em {show['airDate']}")        
         
         # ---- Ended Shows ----
-        # The find_ended_shows function doesn't have a skip_unmonitored parameter
-        # as it's based on show status rather than monitoring status
+        # A função find_end_shows não possui um parâmetro skip_unmonitored
+        # como é baseado no status do show, em vez de monitorar o status
         ended_shows, cancelled_shows = find_ended_shows(
             sonarr_url, sonarr_api_key, tmdb_api_key
         )
-        # Filter out shows that are in the season finale or final episode categories
+        # Filtrar os programas que estão no final da temporada ou em categorias de episódios finais
         ended_shows = [
             show
             for show in ended_shows
@@ -2370,8 +2367,9 @@ def main():
         minutes, seconds = divmod(remainder, 60)
         runtime_formatted = f"{int(hours):02d}:{int(minutes):02d}:{int(seconds):02d}"
         
-        print(f"{AZUL}{AZUL}{'*' * 110}\n{'*' * 3}{' ' * 5}Inicio do Processo: {start_time.strftime('%H:%M:%S')}{' ' * 4}Fim do Processo: {end_time.strftime('%H:%M:%S')}{' ' * 4}Tempo Total de Execução: {runtime_formatted}{' ' * 5}{'*' * 3}\n{'*' * 110}")
-
+        print(f"{AZUL}{AZUL}{'*' * 110}\n{'*' * 3}{' ' * 5}Inicio do Processo: {start_time.strftime('%H:%M:%S')}{' ' * 4}Fim do Processo: {end_time.strftime('%H:%M:%S')}{' ' * 4}Tempo Total de Execução: {runtime_formatted}{' ' * 5}{'*' * 3}\n{'*' * 110}{RESET}")
+        print("")
+        
     except ConnectionError as e:
         print(f"{VERMELHO}Error: {str(e)}{RESET}")
         sys.exit(1)

--- a/TSSK.py
+++ b/TSSK.py
@@ -1661,9 +1661,9 @@ def create_collection_yaml(output_file, shows, config):
 
 def main():
     if IS_DOCKER:
-        end_time = datetime.now(user_tz)
+        start_time = datetime.now(user_tz)
     else:
-        end_time = datetime.now()
+        start_time = datetime.now()
     
     print(f"\n{AZUL}{'*' * 40}\n{'*' * 14} {VERMELHO}TSSK {VERSION}{AZUL} {'*' * 14}\n{'*' * 40}{RESET}")
     print(f"\n{AZUL}Inicio do Processo: {start_time.strftime('%H:%M:%S')}\n")

--- a/TSSK.py
+++ b/TSSK.py
@@ -14,6 +14,14 @@ print = functools.partial(print, flush=True)
 IS_DOCKER = os.getenv("DOCKER", "false").lower() == "true"
 VERSION = "2.0.0"
 
+# ANSI color codes
+GREEN = '\033[32m'
+ORANGE = '\033[33m'
+BLUE = '\033[34m'
+RED = '\033[31m'
+RESET = '\033[0m'
+BOLD = '\033[1m'
+
 if IS_DOCKER:
     os.makedirs("/app/config/kometa/tssk", exist_ok=True)
     puid = int(os.getenv("PUID", "1000"))
@@ -23,15 +31,6 @@ if IS_DOCKER:
     print(f"{BLUE}DOCKER {IS_DOCKER}")
     print(f"{BLUE}PUID {puid}")
     print(f"{BLUE}PGID {pgid}")
-
-
-# ANSI color codes
-GREEN = '\033[32m'
-ORANGE = '\033[33m'
-BLUE = '\033[34m'
-RED = '\033[31m'
-RESET = '\033[0m'
-BOLD = '\033[1m'
 
 def check_for_updates():
     print(f"Verificando atualizações para TSSK {VERSION}...")

--- a/TSSK.py
+++ b/TSSK.py
@@ -1737,7 +1737,7 @@ def concatenate_collections(is_docker, collection_path="",delete_collections_aft
     output_file_name = "TSSK_ALL_COLLECTIONS_TOGETHER.yml" #Não pode terminar com collection.yml para evitar loop infito das informações.
     
     # Define o diretório de busca com base em IS_DOCKER
-    base_path = overlay_path if is_docker else "."
+    base_path = collection_path if is_docker else "."
 
     # Encontra todos os arquivos .yml de overlays e os ordena numericamente
     collection_files = sorted([f for f in os.listdir(base_path) if f.endswith('_COLLECTION.yml')])

--- a/TSSK.py
+++ b/TSSK.py
@@ -137,7 +137,7 @@ def get_tmdb_status(tvdb_id, tmdb_api_key):
     try:
         # First call to find the TMDB id from the TVDB id
         find_url = (
-            f"http://api.themoviedb.org/3/find/{tvdb_id}?api_key="
+            f"https://api.themoviedb.org/3/find/{tvdb_id}?api_key="
             f"{tmdb_api_key}&external_source=tvdb_id"
         )
         resp = requests.get(find_url, timeout=10)
@@ -150,7 +150,7 @@ def get_tmdb_status(tvdb_id, tmdb_api_key):
         if not tmdb_id:
             return None
 
-        details_url = f"http://api.themoviedb.org/3/tv/{tmdb_id}?api_key={tmdb_api_key}"
+        details_url = f"https://api.themoviedb.org/3/tv/{tmdb_id}?api_key={tmdb_api_key}"
         resp = requests.get(details_url, timeout=10)
         resp.raise_for_status()
         info = resp.json()

--- a/TSSK.py
+++ b/TSSK.py
@@ -1560,7 +1560,7 @@ def concatenate_overlays(is_docker, overlay_path=""):
     print(f"\n{VERDE}Todos os arquivos foram combinados em {output_file_name} com sucesso!{RESET}")
     
     #Deleta os arquivos originais se true no arquivo de configuração
-    delete_overlay_after_all_in_one = config.get('delete_overlay_after_all_in_one', "false").lower() == "true"
+    delete_overlay_after_all_in_one = config.get('delete_overlay_after_all_in_one', "false")
     if delete_overlay_after_all_in_one:
         print(f"{AZUL}Deletando os arquivos de overlay originais...{RESET}")
         for file_name in overlay_files:
@@ -1774,7 +1774,7 @@ def concatenate_collections(is_docker, collection_path=""):
     print(f"\n{VERDE}Todos os arquivos foram combinados em {output_file_name} com sucesso!{RESET}")
     
     #Deleta os arquivos originais se true no arquivo de configuração
-    delete_collections_after_all_in_one = config.get('delete_collections_after_all_in_one', "false").lower() == "true"
+    delete_collections_after_all_in_one = config.get('delete_collections_after_all_in_one', "false")
     if delete_collections_after_all_in_one:
         print(f"{AZUL}Deletando os arquivos de overlay originais...{RESET}")
         for file_name in overlay_files:

--- a/TSSK.py
+++ b/TSSK.py
@@ -1523,7 +1523,7 @@ def concatenate_overlays(is_docker, overlay_path="",delete_overlay_after_all_in_
         print(f"{LARANJA}Nenhum arquivo de overlay encontrado para concatenar.{RESET}")
         return
 
-    backdrop_count = 1
+    line_count = 1
     with open(os.path.join(base_path, output_file_name), "w", encoding="utf-8") as outfile:
         # Escreve a linha de cabeçalho 'overlays:'
         outfile.write("overlays:\n")
@@ -1543,7 +1543,14 @@ def concatenate_overlays(is_docker, overlay_path="",delete_overlay_after_all_in_
                         
                         # Substitui 'backdrop:' por 'backdropX:'
                         if "backdrop:" in line:
-                            modified_line = line.replace("backdrop:", f"backdrop{backdrop_count}:")
+                            modified_line = line.replace("backdrop:", f"backdrop{line_count}:")
+                            outfile.write(modified_line)
+                        else:
+                            outfile.write(line)
+                            
+                        # Substitui 'TSSK:' por 'TSSKX:'
+                        if "TSSK" in line:
+                            modified_line = line.replace("TSSK", f"TSSK{line_count}{line[-10:]}")
                             outfile.write(modified_line)
                         else:
                             outfile.write(line)
@@ -1555,7 +1562,7 @@ def concatenate_overlays(is_docker, overlay_path="",delete_overlay_after_all_in_
                 print(f"{VERMELHO}Erro ao processar o arquivo {file_path}: {e}{RESET}")
                 continue
             
-            backdrop_count += 1
+            line_count += 1
             
     print(f"\n{VERDE}Todos os arquivos foram combinados em {output_file_name} com sucesso!{RESET}")
     
@@ -1762,6 +1769,8 @@ def concatenate_collections(is_docker, collection_path="",delete_collections_aft
                     for i, line in enumerate(lines):
                         if i == 0:
                             continue  # Pula a primeira linha
+                        
+                            outfile.write(line) # Copia linhas seguintes para o arquivo.
                             
             except FileNotFoundError:
                 print(f"{VERMELHO}Erro: O arquivo {file_path} não foi encontrado. Pulando este arquivo.{RESET}")

--- a/TSSK.py
+++ b/TSSK.py
@@ -1775,7 +1775,7 @@ def concatenate_collections(is_docker, collection_path="",delete_collections_aft
     #Deleta os arquivos originais se true no arquivo de configuração
     if delete_collections_after_all_in_one:
         print(f"{AZUL}Deletando os arquivos de overlay originais...{RESET}")
-        for file_name in overlay_files:
+        for file_name in collection_files:
             file_path = os.path.join(base_path, file_name)
             try:
                 os.remove(file_path)

--- a/TSSK.py
+++ b/TSSK.py
@@ -1502,7 +1502,7 @@ def create_new_episode_released_overlay_yaml(output_file, config_sections, recen
         yaml.dump(final_output, f, sort_keys=False, allow_unicode=True)
 ##############################END PLEX BASED CONFIG##############################
 
-def concatenate_overlays(is_docker, overlay_path=""):
+def concatenate_overlays(is_docker, overlay_path="",delete_overlay_after_all_in_one=False):
     """
     Combina arquivos YML de overlays em um único arquivo chamado TSSK_TV_ALL_OVERLAYS_TOGETHER.yml.
 
@@ -1560,7 +1560,6 @@ def concatenate_overlays(is_docker, overlay_path=""):
     print(f"\n{VERDE}Todos os arquivos foram combinados em {output_file_name} com sucesso!{RESET}")
     
     #Deleta os arquivos originais se true no arquivo de configuração
-    delete_overlay_after_all_in_one = config.get('delete_overlay_after_all_in_one', "false")
     if delete_overlay_after_all_in_one:
         print(f"{AZUL}Deletando os arquivos de overlay originais...{RESET}")
         for file_name in overlay_files:
@@ -1726,7 +1725,7 @@ def create_collection_yaml(output_file, shows, config):
         # Use SafeDumper so our custom representer is used
         yaml.dump(data, f, Dumper=yaml.SafeDumper, sort_keys=False, allow_unicode=True)
 
-def concatenate_collections(is_docker, collection_path=""):
+def concatenate_collections(is_docker, collection_path="",delete_collections_after_all_in_one=False):
     """
     Combina arquivos YML de coleção em um único arquivo chamado TSSK_ALL_COLLECTIONS_TOGETHER.yml.
 
@@ -1774,7 +1773,6 @@ def concatenate_collections(is_docker, collection_path=""):
     print(f"\n{VERDE}Todos os arquivos foram combinados em {output_file_name} com sucesso!{RESET}")
     
     #Deleta os arquivos originais se true no arquivo de configuração
-    delete_collections_after_all_in_one = config.get('delete_collections_after_all_in_one', "false")
     if delete_collections_after_all_in_one:
         print(f"{AZUL}Deletando os arquivos de overlay originais...{RESET}")
         for file_name in overlay_files:
@@ -2339,14 +2337,16 @@ def main():
             create_collection_yaml("TSSK_TV_RETORNANDO_COLLECTION.yml", returning_shows, config)
         
         #Concatenar todos os arquivos overlay em um único arquivo, para serem aplicados de uma só vez.
-        generate_all_in_one_overlays = config.get('generate_all_in_one_overlays', "false")
+        generate_all_in_one_overlays = config.get('generate_all_in_one_overlays', "false").lower() == "true"
+        delete_overlay_after_all_in_one = config.get('delete_overlay_after_all_in_one', "false").lower() == "true"
         if generate_all_in_one_overlays:
-            concatenate_overlays(IS_DOCKER, overlay_path)
+            concatenate_overlays(IS_DOCKER, overlay_path,delete_overlay_after_all_in_one)
             
         #Concatenar todos os arquivos coleção em um único arquivo, para serem aplicados de uma só vez.
-        generate_all_in_one_collections = config.get('generate_all_in_one_collections', "false")
+        generate_all_in_one_collections = config.get('generate_all_in_one_collections', "false").lower() == "true"
+        delete_collections_after_all_in_one = config.get('delete_collections_after_all_in_one', "false").lower() == "true"
         if generate_all_in_one_collections:
-            concatenate_collection(IS_DOCKER, collection_path)
+            concatenate_collections(IS_DOCKER, collection_path,delete_collections_after_all_in_one)
             
         print(f"\nTodos os arquivos YAML criados com sucesso\n")
 

--- a/TSSK.py
+++ b/TSSK.py
@@ -1730,7 +1730,7 @@ def create_collection_yaml(output_file, shows, config):
         yaml.dump(data, f, Dumper=yaml.SafeDumper, sort_keys=False, allow_unicode=True)
 
 def concatenate_collections(is_docker, collection_path="",delete_collections_after_all_in_one=False,generate_all_in_one_collections=False):
-    """
+    """ 
     Combina arquivos YML de coleção em um único arquivo chamado TSSK_ALL_COLLECTIONS_TOGETHER.yml.
 
     Args:

--- a/TSSK.py
+++ b/TSSK.py
@@ -1502,7 +1502,7 @@ def create_new_episode_released_overlay_yaml(output_file, config_sections, recen
         yaml.dump(final_output, f, sort_keys=False, allow_unicode=True)
 ##############################END PLEX BASED CONFIG##############################
 
-def concatenate_overlays(is_docker, overlay_path="",delete_overlay_after_all_in_one=False):
+def concatenate_overlays(is_docker, overlay_path="",delete_overlay_after_all_in_one=False,generate_all_in_one_overlays=False):
     """
     Combina arquivos YML de overlays em um único arquivo chamado TSSK_TV_ALL_OVERLAYS_TOGETHER.yml.
 
@@ -1567,7 +1567,7 @@ def concatenate_overlays(is_docker, overlay_path="",delete_overlay_after_all_in_
     print(f"\n{VERDE}Todos os arquivos foram combinados em {output_file_name} com sucesso!{RESET}")
     
     #Deleta os arquivos originais se true no arquivo de configuração
-    if delete_overlay_after_all_in_one:
+    if delete_overlay_after_all_in_one and generate_all_in_one_overlays:
         print(f"{AZUL}Deletando os arquivos de overlay originais...{RESET}")
         for file_name in overlay_files:
             file_path = os.path.join(base_path, file_name)
@@ -1732,7 +1732,7 @@ def create_collection_yaml(output_file, shows, config):
         # Use SafeDumper so our custom representer is used
         yaml.dump(data, f, Dumper=yaml.SafeDumper, sort_keys=False, allow_unicode=True)
 
-def concatenate_collections(is_docker, collection_path="",delete_collections_after_all_in_one=False):
+def concatenate_collections(is_docker, collection_path="",delete_collections_after_all_in_one=False,generate_all_in_one_collections=False):
     """
     Combina arquivos YML de coleção em um único arquivo chamado TSSK_ALL_COLLECTIONS_TOGETHER.yml.
 
@@ -1782,7 +1782,7 @@ def concatenate_collections(is_docker, collection_path="",delete_collections_aft
     print(f"\n{VERDE}Todos os arquivos foram combinados em {output_file_name} com sucesso!{RESET}")
     
     #Deleta os arquivos originais se true no arquivo de configuração
-    if delete_collections_after_all_in_one:
+    if delete_collections_after_all_in_one and generate_all_in_one_collections:
         print(f"{AZUL}Deletando os arquivos de overlay originais...{RESET}")
         for file_name in collection_files:
             file_path = os.path.join(base_path, file_name)
@@ -2349,13 +2349,13 @@ def main():
         generate_all_in_one_overlays = str(config.get("generate_all_in_one_overlays", "false")).lower() == "true"
         delete_overlay_after_all_in_one = str(config.get("delete_overlay_after_all_in_one", "false")).lower() == "true"
         if generate_all_in_one_overlays:
-            concatenate_overlays(IS_DOCKER, overlay_path,delete_overlay_after_all_in_one)
+            concatenate_overlays(IS_DOCKER, overlay_path,delete_overlay_after_all_in_one,generate_all_in_one_overlays)
             
         #Concatenar todos os arquivos coleção em um único arquivo, para serem aplicados de uma só vez.
         generate_all_in_one_collections = str(config.get("generate_all_in_one_collections", "false")).lower() == "true"
         delete_collections_after_all_in_one = str(config.get("delete_collections_after_all_in_one", "false")).lower() == "true"
         if generate_all_in_one_collections:
-            concatenate_collections(IS_DOCKER, collection_path,delete_collections_after_all_in_one)
+            concatenate_collections(IS_DOCKER, collection_path,delete_collections_after_all_in_one,generate_all_in_one_collections)
             
         print(f"\nTodos os arquivos YAML criados com sucesso\n")
 

--- a/TSSK.py
+++ b/TSSK.py
@@ -20,9 +20,9 @@ if IS_DOCKER:
     pgid = int(os.getenv("PGID", "1000"))
     overlay_path = "/app/config/kometa/tssk/"
     collection_path = "/app/config/kometa/tssk/"
-    print(f"DOCKER {IS_DOCKER}")
-    print(f"puid {puid}")
-    print(f"pgid {pgid}")
+    print(f"{BLUE}DOCKER {IS_DOCKER}")
+    print(f"{BLUE}PUID {puid}")
+    print(f"{BLUE}PGID {pgid}")
 
 
 # ANSI color codes
@@ -134,7 +134,7 @@ def get_tmdb_status(tvdb_id, tmdb_api_key):
     try:
         # First call to find the TMDB id from the TVDB id
         find_url = (
-            f"https://api.themoviedb.org/3/find/{tvdb_id}?api_key="
+            f"http://api.themoviedb.org/3/find/{tvdb_id}?api_key="
             f"{tmdb_api_key}&external_source=tvdb_id"
         )
         resp = requests.get(find_url, timeout=10)
@@ -147,7 +147,7 @@ def get_tmdb_status(tvdb_id, tmdb_api_key):
         if not tmdb_id:
             return None
 
-        details_url = f"https://api.themoviedb.org/3/tv/{tmdb_id}?api_key={tmdb_api_key}"
+        details_url = f"http://api.themoviedb.org/3/tv/{tmdb_id}?api_key={tmdb_api_key}"
         resp = requests.get(details_url, timeout=10)
         resp.raise_for_status()
         info = resp.json()
@@ -961,32 +961,20 @@ def create_overlay_yaml(output_file, shows, config_sections):
             tvdb_ids_str = ", ".join(str(i) for i in sorted(all_tvdb_ids) if i)
             
             # Extract category name from filename
-        #    if "NOVA_TEMPORADA_INICIADA" in output_file:
-        #        block_key = "TSSK_new_season_started"
-        #    elif "FIM_TEMPORADA" in output_file:
-        #        block_key = "TSSK_season_finale"
-        #    elif "EPISODIO_FINAL" in output_file:
-        #        block_key = "TSSK_final_episode"
-        #    elif "FINALIZADOS" in output_file:
-        #        block_key = "TSSK_ended"
-        #    elif "RETURNING" in output_file:
-        #        block_key = "TSSK_returning"
-        #    else:
-        #        block_key = "TSSK_text"  # fallback
-
-            # Extract category name from filename
             if "NOVA_TEMPORADA_INICIADA" in output_file:
-                block_key = "TSSK_new_season_started"
+                block_key = "TSSK_nova_temporada_iniciada"
             elif "FIM_TEMPORADA" in output_file:
-                block_key = "TSSK_season_finale"
+                block_key = "TSSK_final_de_temporada"
             elif "EPISODIO_FINAL" in output_file:
-                block_key = "TSSK_final_episode"
+                block_key = "TSSK_episódio_final"
             elif "FINALIZADOS" in output_file:
-                block_key = "TSSK_ended"
+                block_key = "TSSK_finalizados"
             elif "RETORNANDO" in output_file:
-                block_key = "TSSK_returning"
+                block_key = "TSSK_retornando"
+            elif "CANCELADOS" in output_file:
+                block_key = "TSSK_cancelados"
             else:
-                block_key = "TSSK_text"  # fallback
+                block_key = "TSSK_overlay"  # fallback
             
             overlays_dict[block_key] = {
                 "overlay": sub_overlay_config,
@@ -1034,7 +1022,7 @@ def create_new_episode_added_overlay_yaml(output_file, config_sections, recent_d
         
         text_config["name"] = f"text({use_text})"
         
-        overlays_dict["new_recent_episode"] = {
+        overlays_dict["episodios_recen_adicionados_nv_seriado"] = {
             "run_definition": "show",
             "builder_level": "show",
             "plex_search": {
@@ -1084,7 +1072,7 @@ def create_recent_new_episode_added_overlay_yaml(output_file, config_sections, r
         
         text_config["name"] = f"text({use_text})"
         
-        overlays_dict["fresh_new_recent_episode"] = {
+        overlays_dict["episodios_novos_adicionados_nv_seriado"] = {
             "run_definition": "show",
             "builder_level": "show",
             "plex_search": {
@@ -1135,7 +1123,7 @@ def create_new_season_added_overlay_yaml(output_file, config_sections, recent_da
         
         text_config["name"] = f"text({use_text})"
         
-        overlays_dict["fresh_new_recent_season"] = {
+        overlays_dict["nova_temporada_adicionada_nv_seriado"] = {
             "run_definition": "show",
             "builder_level": "show",
             "plex_search": {
@@ -1186,7 +1174,7 @@ def create_new_show_overlay_yaml(output_file, config_sections, recent_days):
         
         text_config["name"] = f"text({use_text})"
         
-        overlays_dict["new_show"] = {
+        overlays_dict["seriado_adicionado_recentemente_nv_seriado"] = {
             "run_definition": "show",
             "builder_level": "show",
             "plex_search": {
@@ -1238,7 +1226,7 @@ def create_episode_on_season_overlay_yaml(output_file, config_sections, recent_d
         
         text_config["name"] = f"text({use_text})"
         
-        overlays_dict["episode_season"] = {
+        overlays_dict["episodio_adicionado_temporada_nv_temporada"] = {
             "run_definition": "show",
             "builder_level": "season",
             "plex_search": {
@@ -1289,7 +1277,7 @@ def create_new_episode_on_season_overlay_yaml(output_file, config_sections, rece
         
         text_config["name"] = f"text({use_text})"
         
-        overlays_dict["new_episode_season"] = {
+        overlays_dict["episodio_novo_temporada_nv_temporada"] = {
             "run_definition": "show",
             "builder_level": "season",
             "plex_search": {
@@ -1340,7 +1328,7 @@ def create_season_added_overlay_yaml(output_file, config_sections, recent_days):
         
         text_config["name"] = f"text({use_text})"
         
-        overlays_dict["new_season"] = {
+        overlays_dict["temporada_adicionada_nv_temporada"] = {
             "run_definition": "show",
             "builder_level": "season",
             "plex_search": {
@@ -1392,7 +1380,7 @@ def create_new_season_released_overlay_yaml(output_file, config_sections, recent
         
         text_config["name"] = f"text({use_text})"
         
-        overlays_dict["new_released_season"] = {
+        overlays_dict["nova_temporada_adicionada_nv_temporada"] = {
             "run_definition": "show",
             "builder_level": "season",
             "plex_search": {
@@ -1444,7 +1432,7 @@ def create_episode_added_overlay_yaml(output_file, config_sections, recent_days)
         
         text_config["name"] = f"text({use_text})"
         
-        overlays_dict["new_released_season"] = {
+        overlays_dict["episodio_adicionado_nv_episodio"] = {
             "run_definition": "show",
             "builder_level": "episode",
             "plex_search": {
@@ -1495,7 +1483,7 @@ def create_new_episode_released_overlay_yaml(output_file, config_sections, recen
         
         text_config["name"] = f"text({use_text})"
         
-        overlays_dict["new_released_season"] = {
+        overlays_dict["novo_episodio_adicionado_nv_episodio"] = {
             "run_definition": "show",
             "builder_level": "episode",
             "plex_search": {
@@ -1529,34 +1517,37 @@ def create_collection_yaml(output_file, shows, config):
     collection_name = ""
     
     if "FIM_TEMPORADA" in output_file:
-        config_key = "collection_season_finale"
+        config_key = "colecao_fim_temporada"
         summary = f"Seriados com um final de temporada que foi ao ar nós últimos {config.get('recent_days_season_finale', 21)} dias"
     elif "EPISODIO_FINAL" in output_file:
-        config_key = "collection_final_episode"
+        config_key = "colecao_episodio_final"
         summary = f"Seriados com um episódio final que foi ao ar nós últimos {config.get('recent_days_final_episode', 21)} dias"
     elif "NOVA_TEMPORADA_INICIADA" in output_file:
-        config_key = "collection_new_season_started"
+        config_key = "colecao_nova_temporada_iniciada"
         summary = f"Seriados com uma nova temporada que começou no passado {config.get('recent_days_new_season_started', 14)} days"
     elif "NOVA_TEMPORADA" in output_file:
-        config_key = "collection_new_season"
+        config_key = "colecao_nova_temporada"
         summary = f"Seriados com uma nova temporada começando dentro {config.get('future_days_new_season', 31)} days"
     elif "PROXIMOS_EPISODIOS" in output_file:
-        config_key = "collection_upcoming_episode"
+        config_key = "colecao_proximos_episodios"
         summary = f"Seriados com um próximo episódio dentro {config.get('future_days_upcoming_episode', 31)} days"
     elif "PROXIMOS_FINAIS" in output_file:
-        config_key = "collection_upcoming_finale"
+        config_key = "colecao_procimos_finais"
         summary = f"Seriados com um final de temporada dentro de {config.get('future_days_upcoming_finale', 31)} days"
     elif "FINALIZADOS" in output_file:
-        config_key = "collection_ended"
+        config_key = "colecao_finalizados"
         summary = "Seriados que já foram Finalizados."
-    elif "RETURNING" in output_file:
-        config_key = "collection_returning"
-        summary = "Retornando programas sem os próximos episódios dentro dos prazos escolhidos"
+    elif "CANCELADOS" in output_file:
+        config_key = "colecao_cancelados"
+        summary = "Seriados que foram cancelados."
+    elif "RETORNANDO" in output_file:
+        config_key = "colecao_seriados_que_retornarao"
+        summary = "Seriados que tiveram seu retorno confirmado"
     else:
         # Default fallback
         config_key = None
-        collection_name = "TV Collection"
-        summary = "TV Collection"
+        collection_name = "colecao_de_seriados"
+        summary = "Coleção de Seriados"
     
     # Get the collection configuration if available
     if config_key and config_key in config:
@@ -1668,6 +1659,7 @@ def create_collection_yaml(output_file, shows, config):
 def main():
     start_time = datetime.now()
     print(f"{BLUE}{'*' * 40}\n{'*' * 15} TSSK {VERSION} {'*' * 15}\n{'*' * 40}{RESET}")
+    print(f"\n{BLUE}Inicio do Processo: {start_time.strftime('%H:%M:%S')}\n")
     check_for_updates()
 
     config = load_config('config/config.yml')
@@ -2130,14 +2122,12 @@ def main():
         ended_shows, cancelled_shows = find_ended_shows(
             sonarr_url, sonarr_api_key, tmdb_api_key
         )
-
         # Filter out shows that are in the season finale or final episode categories
         ended_shows = [
             show
             for show in ended_shows
             if show.get("tvdbId") not in all_excluded_tvdb_ids
         ]
-
         cancelled_shows = [
             show
             for show in cancelled_shows
@@ -2153,22 +2143,16 @@ def main():
             if show.get("tvdbId"):
                 all_included_tvdb_ids.add(show["tvdbId"])
 
-                if ended_shows:
-                    print(f"\n{GREEN}Seriados Finalizados:{RESET}")
-                    for show in ended_shows:
-                        print(f"- {show['title']}")
-                
-                if cancelled_shows:
+        # ---- Cancelled Shows ----
+        if cancelled_shows:
                     print(f"\n{GREEN}Seriados que foram Cancelados:{RESET}")
                     for show in cancelled_shows:
                         print(f"- {show['title']}")
                         
-                        
-        # ---- Cancelled Shows ----
         if IS_DOCKER:
             create_overlay_yaml(overlay_path + "00_TSSK_TV_CANCELADOS_OVERLAYS.yml", cancelled_shows, 
-                               {"backdrop": config.get("backdrop_ended", {}),
-                                "text": config.get("text_ended", {})})
+                               {"backdrop": config.get("backdrop_cancelled", {}),
+                                "text": config.get("text_cancelled", {})})
         
             create_collection_yaml(collection_path + "TSSK_TV_CANCELADOS_COLLECTION.yml", cancelled_shows, config)
             
@@ -2177,12 +2161,16 @@ def main():
 
         else:
             create_overlay_yaml("00_TSSK_TV_CANCELADOS_OVERLAYS.yml", cancelled_shows, 
-                               {"backdrop": config.get("backdrop_ended", {}),
-                                "text": config.get("text_ended", {})})
+                               {"backdrop": config.get("backdrop_cancelled", {}),
+                                "text": config.get("text_cancelled", {})})
         
             create_collection_yaml("TSSK_TV_CANCELADOS_COLLECTION.yml", cancelled_shows, config)
         
         # ---- Ended Shows ----
+        if ended_shows:
+                    print(f"\n{GREEN}Seriados já Finalizados:{RESET}")
+                    for show in ended_shows:
+                        print(f"- {show['title']}")
         if IS_DOCKER:
             create_overlay_yaml(overlay_path + "01_TSSK_TV_FINALIZADOS_OVERLAYS.yml", ended_shows, 
                                {"backdrop": config.get("backdrop_ended", {}),
@@ -2206,7 +2194,7 @@ def main():
         returning_shows = [show for show in returning_shows if show.get('tvdbId') not in all_excluded_tvdb_ids]
         
         if returning_shows:
-            print(f"\n{GREEN}Shows that are continuing but don't have scheduled episodes:{RESET}")
+            print(f"\n{GREEN}Seriados que não foram cancelados, mas não tem data de retorno:{RESET}")
             for show in returning_shows:
                 print(f"- {show['title']}")
         
@@ -2236,7 +2224,7 @@ def main():
         minutes, seconds = divmod(remainder, 60)
         runtime_formatted = f"{int(hours):02d}:{int(minutes):02d}:{int(seconds):02d}"
         
-        print(f"Total runtime: {runtime_formatted}")
+        print(f"{BLUE}{BLUE}{'*' * 110}\n{'*' * 3}{' ' * 5}Inicio do Processo: {start_time.strftime('%H:%M:%S')}{' ' * 4}Fim do Processo: {end_time.strftime('%H:%M:%S')}{' ' * 4}Tempo Total de Execução: {runtime_formatted}{' ' * 5}{'*' * 3}\n{'*' * 110}")
 
     except ConnectionError as e:
         print(f"{RED}Error: {str(e)}{RESET}")

--- a/TSSK.py
+++ b/TSSK.py
@@ -2337,14 +2337,14 @@ def main():
             create_collection_yaml("TSSK_TV_RETORNANDO_COLLECTION.yml", returning_shows, config)
         
         #Concatenar todos os arquivos overlay em um único arquivo, para serem aplicados de uma só vez.
-        generate_all_in_one_overlays = config.get('generate_all_in_one_overlays', "false").lower() == "true"
-        delete_overlay_after_all_in_one = config.get('delete_overlay_after_all_in_one', "false").lower() == "true"
+        generate_all_in_one_overlays = str(config.get("generate_all_in_one_overlays", "false")).lower() == "true"
+        delete_overlay_after_all_in_one = str(config.get("delete_overlay_after_all_in_one", "false")).lower() == "true"
         if generate_all_in_one_overlays:
             concatenate_overlays(IS_DOCKER, overlay_path,delete_overlay_after_all_in_one)
             
         #Concatenar todos os arquivos coleção em um único arquivo, para serem aplicados de uma só vez.
-        generate_all_in_one_collections = config.get('generate_all_in_one_collections', "false").lower() == "true"
-        delete_collections_after_all_in_one = config.get('delete_collections_after_all_in_one', "false").lower() == "true"
+        generate_all_in_one_collections = str(config.get("generate_all_in_one_collections", "false")).lower() == "true"
+        delete_collections_after_all_in_one = str(config.get("delete_collections_after_all_in_one", "false")).lower() == "true"
         if generate_all_in_one_collections:
             concatenate_collections(IS_DOCKER, collection_path,delete_collections_after_all_in_one)
             

--- a/TSSK.py
+++ b/TSSK.py
@@ -1770,7 +1770,7 @@ def concatenate_collections(is_docker, collection_path="",delete_collections_aft
                         if i == 0:
                             continue  # Pula a primeira linha
                         
-                            outfile.write(line) # Copia linhas seguintes para o arquivo.
+                            outfile.write(line) # Copia linhas seguintes para o arquivo. 
                             
             except FileNotFoundError:
                 print(f"{VERMELHO}Erro: O arquivo {file_path} não foi encontrado. Pulando este arquivo.{RESET}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   tssk:
-    image: joaopaulofvaz/tssk
+    image: joaopaulofvaz/tssk:latest
     container_name: tssk
     environment:
       - CRON=0 2 * * * # todos os dias às 02h da manhã

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,7 +25,7 @@ echo "$CRON source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>
 
 chmod 0644 /etc/cron.d/tssk-cron
 crontab /etc/cron.d/tssk-cron
-echo "TSSK is starting with the following cron schedule: $CRON"
+echo "O TSSK está sendo iniciado com a seguinte programação cron : $CRON"
 
 touch /var/log/cron.log
 cron

--- a/files/config.example.yml
+++ b/files/config.example.yml
@@ -2,6 +2,12 @@ sonarr_url: 'http://192.168.0.1:8989'
 sonarr_api_key: 'seu_api_sonarr'
 
 skip_unmonitored: false #Ajuste para falso se quiser monitorar também o que não está sendo monitorado pelo Sonarr
+
+#Gerar arquivos únicos de coleção e overlay, útil se deseja utilizar todos de uma vez.
+generate_all_in_one_overlays: false # marque true para habilitar a geração de arquivo único para overlay.
+delete_overlay_after_all_in_one: false # marque false para deletar arquivos base apos concatenar os originais.
+generate_all_in_one_collections: false # marque true para habilitar a geração de arquivo único para coleção
+delete_collections_after_all_in_one: false # marque false para deletar arquivos base apos concatenar os originais.
 utc_offset: +0
 
 ################################################################################
@@ -96,8 +102,6 @@ backdrop_upcoming_episode:
   vertical_align: bottom
   vertical_offset: 0
   
-
-
 text_upcoming_episode:
   date_format: "ddd dd/mm"
   capitalize_dates: true
@@ -133,7 +137,6 @@ backdrop_upcoming_finale:
   vertical_align: bottom
   vertical_offset: 0
 
-
 text_upcoming_finale:
   date_format: "ddd dd/mm"      # e.g., "yyyy-mm-dd", "mm/dd", "dd/mm", etc.
   capitalize_dates: true
@@ -146,6 +149,37 @@ text_upcoming_finale:
   font_color: "#FFFFFF" #BRANCO
   #font: Ajuste com a fonte dessejada.
 
+################################################################################
+##########                           CANCELADOS:                      ##########
+################################################################################
+#Arquivo: 00_TSSK_TV_CANCELADOS_OVERLAYS.yml
+
+collection_cancelled:
+  collection_name: "Seriados Cancelados"
+  smart_label: title.desc
+  sort_title: "+1_2Seriados Cancelados"
+  ignore_blank_results: true
+
+backdrop_cancelled:
+  enable: true
+  back_color: "#000000" #PRETO
+  back_height: 90
+  back_width: 1000
+  horizontal_align: center
+  horizontal_offset: 0
+  vertical_align: bottom
+  vertical_offset: 0
+
+text_cancelled:
+  use_text: "SERIADO CANCELADO"
+  horizontal_align: center
+  horizontal_offset: 0
+  vertical_align: bottom
+  vertical_offset: 15
+  font_size: 65
+  font_color: "#00ff3d" #VERDE
+  #font: Ajuste com a fonte dessejada.
+  
 ################################################################################
 ##########                           FINALIZADO:                      ##########
 ################################################################################
@@ -167,9 +201,8 @@ backdrop_ended:
   vertical_align: bottom
   vertical_offset: 0
 
-
 text_ended:
-  use_text: "F I N A L I Z A D O"
+  use_text: "SERIADO FINALIZADO"
   horizontal_align: center
   horizontal_offset: 0
   vertical_align: bottom
@@ -199,9 +232,8 @@ backdrop_returning:
   vertical_align: bottom
   vertical_offset: 0
 
-
 text_returning:
-  use_text: "R E T O R N A N D O"
+  use_text: "EM BREVE NOVOS EPISÓDIOS"
   horizontal_align: center
   horizontal_offset: 0
   vertical_align: bottom
@@ -231,7 +263,6 @@ backdrop_season_finale:
   horizontal_offset: 0
   vertical_align: bottom
   vertical_offset: 0
-
 
 text_season_finale:
   use_text: "FINAL DE TEMPORADA"
@@ -264,7 +295,6 @@ backdrop_final_episode:
   horizontal_offset: 0
   vertical_align: bottom
   vertical_offset: 0
-
 
 text_final_episode:
   use_text: "EPISÓDIO FINAL"
@@ -299,7 +329,6 @@ backdrop_new_episode_added:
   vertical_align: bottom
   vertical_offset: 0
 
-
 text_new_episode_added:
   use_text: "NOVOS EPISÓDIOS"
   horizontal_align: center
@@ -327,7 +356,6 @@ backdrop_recent_new_episode_added:
   horizontal_offset: 0
   vertical_align: bottom
   vertical_offset: 0
-
 
 text_recent_new_episode_added:
   use_text: "EPISÓDIO NOVO"
@@ -357,7 +385,6 @@ backdrop_new_season_added:
   vertical_align: bottom
   vertical_offset: 0
 
-
 text_new_season_added:
   use_text: "TEMPORADA ATUALIZADA"
   horizontal_align: center
@@ -384,7 +411,6 @@ backdrop_new_show:
   horizontal_offset: 0
   vertical_align: bottom
   vertical_offset: 0
-
 
 text_new_show:
   use_text: "ADICIONADO RECENTEMENTE"
@@ -416,7 +442,6 @@ backdrop_episode_season:
   vertical_align: bottom
   vertical_offset: 0
 
-
 text_episode_season:
   use_text: "NOVOS EPISÓDIOS"
   horizontal_align: center
@@ -444,7 +469,6 @@ backdrop_new_episode_season:
   horizontal_offset: 0
   vertical_align: bottom
   vertical_offset: 0
-
 
 text_new_episode_season:
   use_text: "EPISÓDIO NOVO"
@@ -474,7 +498,6 @@ backdrop_season_added:
   vertical_align: bottom
   vertical_offset: 0
 
-
 text_season_added:
   use_text: "ADICIONADA RECENTEMENTE"
   horizontal_align: center
@@ -500,7 +523,6 @@ backdrop_new_season_released:
   horizontal_offset: 0
   vertical_align: bottom
   vertical_offset: 0
-
 
 text_new_season_released:
   use_text: "NOVA TEMPORADA"
@@ -532,7 +554,6 @@ backdrop_episode_added:
   vertical_align: bottom
   vertical_offset: 0
 
-
 text_episode_added:
   use_text: "ADICIONADO RECENTEMENTE"
   horizontal_align: center
@@ -561,7 +582,6 @@ backdrop_new_episode_released:
   vertical_align: bottom
   vertical_offset: 0
 
-
 text_new_episode_released:
   use_text: "EPISÓDIO NOVO"
   horizontal_align: center
@@ -570,5 +590,4 @@ text_new_episode_released:
   vertical_offset: 15
   font_size: 65
   font_color: "#FFFFFF" #BRANCO
-#font: Ajuste com a fonte dessejada.
-
+#font: Ajuste com a fonte dessejada

--- a/files/config.example.yml
+++ b/files/config.example.yml
@@ -1,13 +1,17 @@
-sonarr_url: 'http://192.168.0.1:8989'
-sonarr_api_key: 'seu_api_sonarr'
+#Obrigatório:
+sonarr_url: 'http://192.168.0.1:8989' #URL do Sonarr
+sonarr_api_key: 'seu_api_sonarr' # API key do Sonarr
+tmdb_api_key: 'seu_api_tmdb'  #  API key TMDb
 
 skip_unmonitored: false #Ajuste para falso se quiser monitorar também o que não está sendo monitorado pelo Sonarr
 
 #Gerar arquivos únicos de coleção e overlay, útil se deseja utilizar todos de uma vez.
 generate_all_in_one_overlays: false # marque true para habilitar a geração de arquivo único para overlay.
-delete_overlay_after_all_in_one: false # marque false para deletar arquivos base apos concatenar os originais.
+delete_overlay_after_all_in_one: true # marque false para deletar arquivos base apos concatenar os originais(depende de generate_all_in_one_overlays).
 generate_all_in_one_collections: false # marque true para habilitar a geração de arquivo único para coleção
-delete_collections_after_all_in_one: false # marque false para deletar arquivos base apos concatenar os originais.
+delete_collections_after_all_in_one: true # marque false para deletar arquivos base apos concatenar os originais depende de (generate_all_in_one_collections).
+
+#Deslocamento de fuso horário
 utc_offset: +0
 
 ################################################################################

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.32.3
 PyYAML==6.0.2
+pytz


### PR DESCRIPTION
- Reativada/Reconfigurada a opção de gerar arquivo de seriados cancelados;
- A partir de agora a informação de cancelados e finalizados será feita de acordo com o status no TVDB.
- Criada lógica para concatenar todas as Overlays em uma, deve ser ativada no arquivo de configuração.
- Criada lógica para concatenar todas as Coleções em uma, deve ser ativada no arquivo de configuração.
