### PR TITLE
v3.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,3 @@ RUN chmod +x /entrypoint.sh
 
 # Start with the entrypoint script (sets up cron)
 ENTRYPOINT ["/entrypoint.sh"]
-
-# Switch to the non-root user for the main process
-USER appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # Define a variável CRON para o agendamento
 ARG CRON="0 2 * * *"
 
+# Define default PUID and PGID for the appuser
+ARG PUID=1000
+ARG PGID=1000
+
 #Set working directory
 WORKDIR /app
 
@@ -15,6 +19,10 @@ WORKDIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends cron tzdata && \
     rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user and group
+RUN groupadd -g ${PGID} appuser && useradd -u ${PUID} -g appuser -m -s /bin/bash appuser
+
 
 # Copy only what we need
 COPY requirements.txt .
@@ -31,3 +39,6 @@ RUN chmod +x /entrypoint.sh
 
 # Start with the entrypoint script (sets up cron)
 ENTRYPOINT ["/entrypoint.sh"]
+
+# Switch to the non-root user for the main process
+USER appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get update && \
 # Create a non-root user and group
 RUN groupadd -g ${PGID} appuser && useradd -u ${PUID} -g appuser -m -s /bin/bash appuser
 
-
 # Copy only what we need
 COPY requirements.txt .
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Este é um fork de https://github.com/netplexflix/TV-show-status-for-Kometa, tod
 * Corrigido o fato do script não salvar os arquivos na pasta do Kometa quando executando em Docker;
 * Inseridos alguns scripts para filtros de situações no passado vindo do Plex.
 * A possibilidade de ativar a opção para que todos os scritps sejam salvos em um único arquivo, economizando tempo de configuração.
+* A possibilidade do agendamento de vários horário para a execução do script.
+* A possibilidade de iniciar o script imediatamente após a inicialização do Docker.
 * Script Traduzido para pt-BR.
 
 # 📺 Status dos Seriados para Kometa

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ docker compose up -d
 
 O que isso fará:
 - Baixa a versão mais recente da imagem `joaopaulofvaz/tssk` no Docker Hub
-- Executa o script dentro em um horário definido ( por padrão 2AM)
+- Executa o script dentro em um horário definido ( por padrão 02:00,08:00,14:00)
 - Monta seu diretório de configuração e diretório de saída dentro do container
 
 Você pode customizar a definição de horário modificando a variável  `CRON` no arquivo `docker-compose.yml`.
@@ -117,21 +117,25 @@ Você pode customizar a definição de horário modificando a variável  `CRON` 
 ```yaml
 services:
   tssk:
-    image: joaopaulofvaz/tssk:testa
+    image: joaopaulofvaz/tssk:latest
     container_name: tssk
     environment:
-      - CRON=02 09 * * * # diariamente às 02AM.
-      - DOCKER=true # importante para referenciamento
+      - HORARIOS_DE_EXECUCAO=02:00,08:00,14:00 # Informe os horários que deseja que o script seja executado (Ex: 08:00)
+      - EXECUTAR_AO_INICIAR=false #Executa imediamentamente ao iniciar.
+      - CRON=00 03 * * * #Opicionalmente informe o cron que deseja executar
+      - DOCKER=true
       - PUID=1000
       - PGID=1000
-      - TZ=America/Sao_Paulo # Ajuste seu fuso horário
+      - TZ=America/Sao_Paulo
     volumes:
-      - /seu/local/config/tssk:/app/config
-      - /seu/local/kometa/config:/app/config/kometa
+      - /home/joaopaulovaz/app/docker/tssk:/app/config
+      - /home/joaopaulovaz/app/docker/kometa/config:/app/config/kometa
     restart: unless-stopped
-    network_mode: bridge
+    network_mode: host
 ```
-
+> [!TIP]
+> Você pode informar os horários que deseja que o script seja executado, ou informar o CRON que deseja, mas o CRON tem prioridade em relação aos Horários de Execução. 
+> Você pode também executar o scprit imediatamente ao iniciar informando true em `EXECUTAR_AO_INICIAR`.
 ---
 
 ### 🧩 Continue a configuração

--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ services:
     image: joaopaulofvaz/tssk:latest
     container_name: tssk
     environment:
-      - HORARIOS_DE_EXECUCAO=02:00,08:00,14:00 # Informe os horários que deseja que o script seja executado (Ex: 08:00)
+      - HORARIOS_DE_EXECUCAO=08:00,20:00 # Informe os horários que deseja que o script seja executado (Ex: 08:00)
       - EXECUTAR_AO_INICIAR=false #Executa imediamentamente ao iniciar.
-      - CRON=00 03 * * * #Opicionalmente informe o cron que deseja executar
+      - CRON=18 16 * * * #Opicionalmente informe o cron que deseja executar (Sobrepõe horário de execução)
       - DOCKER=true
       - PUID=1000
       - PGID=1000
@@ -133,7 +133,7 @@ services:
       - /home/joaopaulovaz/app/docker/tssk:/app/config
       - /home/joaopaulovaz/app/docker/kometa/config:/app/config/kometa
     restart: unless-stopped
-    network_mode: host
+    network_mode: bridge
 ```
 > [!TIP]
 > Você pode informar os horários que deseja que o script seja executado, ou informar o CRON que deseja, mas o CRON tem prioridade em relação aos Horários de Execução. 

--- a/TSSK.py
+++ b/TSSK.py
@@ -15,7 +15,7 @@ print = functools.partial(print, flush=True)
 IS_DOCKER = os.getenv("DOCKER", "false").lower() == "true"
 overlay_path = "/app/config/kometa/tssk/"  if IS_DOCKER else "kometa/"
 collection_path = "/app/config/kometa/tssk/"  if IS_DOCKER else "kometa/"
-VERSION = "2.5.3"
+VERSION = "3.0.0"
 
 # ANSI color codes
 VERDE = '\033[32m'

--- a/TSSK.py
+++ b/TSSK.py
@@ -137,7 +137,7 @@ def get_tmdb_status(tvdb_id, tmdb_api_key):
     try:
         # First call to find the TMDB id from the TVDB id
         find_url = (
-            f"http://api.themoviedb.org/3/find/{tvdb_id}?api_key="
+            f"https://api.themoviedb.org/3/find/{tvdb_id}?api_key="
             f"{tmdb_api_key}&external_source=tvdb_id"
         )
         resp = requests.get(find_url, timeout=10)
@@ -150,7 +150,7 @@ def get_tmdb_status(tvdb_id, tmdb_api_key):
         if not tmdb_id:
             return None
 
-        details_url = f"http://api.themoviedb.org/3/tv/{tmdb_id}?api_key={tmdb_api_key}"
+        details_url = f"https://api.themoviedb.org/3/tv/{tmdb_id}?api_key={tmdb_api_key}"
         resp = requests.get(details_url, timeout=10)
         resp.raise_for_status()
         info = resp.json()

--- a/TSSK.py
+++ b/TSSK.py
@@ -1829,9 +1829,9 @@ def main():
 
         # Print chosen values
         print(f"future_days_new_season: {future_days_new_season}")
-        print(f"recent_days_new_season_started: {recent_days_new_season_started}")
         print(f"future_days_upcoming_episode: {future_days_upcoming_episode}")
         print(f"future_days_upcoming_finale: {future_days_upcoming_finale}")
+        print(f"recent_days_new_season_started: {recent_days_new_season_started}")
         print(f"recent_days_season_finale: {recent_days_season_finale}")
         print(f"recent_days_final_episode: {recent_days_final_episode}")
         print(f"recent_days_new_show: {recent_days_new_show}")

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,8 +19,8 @@ echo "export TZ=$TZ" >> /app/.cron_env # Inclui TZ para o contexto do cron
 > /etc/cron.d/tssk-cron
 
 # Define o shell e o usuário para as tarefas cron
-#echo "SHELL=/bin/bash" > /etc/cron.d/tssk-cron
-#echo "USER=appuser" >> /etc/cron.d/tssk-cron
+echo "SHELL=/bin/bash" >> /etc/cron.d/tssk-cron
+echo "USER=appuser" >> /etc/cron.d/tssk-cron
 
 # Priorizar a nova variável DAILY_TIMES para horários em formato "normal"
 if [ -n "$DAILY_TIMES" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -71,4 +71,4 @@ cat /etc/cron.d/tssk-cron
 echo ""
 
 touch /var/log/cron.log 
-tail -f /var/log/cron.log
+exec tail -f /var/log/cron.log

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,11 +22,11 @@ chown "${PUID}:${PGID}" /app/.cron_env # Garante que o appuser possa ler este ar
 # Define o shell e o usuário para as tarefas cron
 echo "SHELL=/bin/bash" >> /etc/cron.d/tssk-cron
 
-# Priorizar a variável DAILY_TIMES para horários em formato "normal"
-if [ -n "$DAILY_TIMES" ]; then
-    echo "Configurando agendamentos diários a partir de DAILY_TIMES: $DAILY_TIMES"
+# Priorizar a variável HORARIOS_DE_EXECUCAO para horários em formato "normal"
+if [ -n "$HORARIOS_DE_EXECUCAO" ]; then
+    echo "Configurando agendamentos diários a partir de HORARIOS_DE_EXECUCAO: $HORARIOS_DE_EXECUCAO"
     # Remove aspas (simples e duplas) do início e do fim da string para evitar erros de parsing
-    CLEANED_TIMES=$(echo "$DAILY_TIMES" | sed "s/^'//;s/'$//;s/^\"//;s/\"$//")
+    CLEANED_TIMES=$(echo "$HORARIOS_DE_EXECUCAO" | sed "s/^'//;s/'$//;s/^\"//;s/\"$//")
     IFS=',' read -ra ADDR <<< "$CLEANED_TIMES"
     for i in "${ADDR[@]}"; do
         # Remove espaços em branco da string de tempo
@@ -37,22 +37,22 @@ if [ -n "$DAILY_TIMES" ]; then
             echo "$MINUTE $HOUR * * * appuser source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
             echo "  - Tarefa cron adicionada para: $time_str"
         else
-            echo "  - Aviso: Formato de hora inválido '$time_str' em DAILY_TIMES. Esperado HH:MM. Ignorando."
+            echo "  - Aviso: Formato de hora inválido '$time_str' em HORARIOS_DE_EXECUCAO. Esperado HH:MM. Ignorando."
         fi
     done
 elif [ -n "$CRON" ]; then
     echo "Configurando agendamento a partir de CRON: $CRON"
     echo "$CRON appuser source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
 else
-    echo "Nenhuma variável de ambiente DAILY_TIMES ou CRON foi definida. Nenhuma tarefa cron será agendada."
+    echo "Nenhuma variável de ambiente HORARIOS_DE_EXECUCAO ou CRON foi definida. Nenhuma tarefa cron será agendada."
     echo "# Nenhuma tarefa cron configurada." >> /etc/cron.d/tssk-cron # Garante que o arquivo não fique vazio
 fi
 
 chmod 0644 /etc/cron.d/tssk-cron
 
-# Verifica se a variável RUN_ON_STARTUP está definida como "true" (ignorando maiúsculas/minúsculas)
-if [[ "${RUN_ON_STARTUP,,}" == "true" ]]; then
-    echo "Executando o script imediatamente na inicialização (RUN_ON_STARTUP=true)..."
+# Verifica se a variável EXECUTAR_AO_INICIAR está definida como "true" (ignorando maiúsculas/minúsculas)
+if [[ "${EXECUTAR_AO_INICIAR,,}" == "true" ]]; then
+    echo "Executando o script imediatamente na inicialização (EXECUTAR_AO_INICIAR=true)..."
     # Executa como 'appuser' para manter a consistência de permissões com os trabalhos do cron.
     su -s /bin/bash -c "source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py" appuser 2>&1 | tee -a /var/log/cron.log &
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-# Verifica se o usuário 'appuser' existe. Se não, encerra com erro.
-if ! id -u appuser >/dev/null 2>&1; then
-    echo "Erro: O usuário 'appuser' não existe na imagem. A imagem Docker precisa ser construída com este usuário."
-    exit 1
-fi
+# Create a non-root user and group
+RUN groupadd -g ${PGID} appuser && useradd -u ${PUID} -g appuser -m -s /bin/bash appuser
+
 
 # Cria a pasta /app/config se não existir
 mkdir -p /app/config/kometa/tssk

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,8 +35,8 @@ elif [ -n "$HORARIOS_DE_EXECUCAO" ]; then
         # Remove espaços em branco da string de tempo
         time_str=$(echo "$i" | xargs)
         if [[ "$time_str" =~ ^([0-1]?[0-9]|2[0-3]):([0-5]?[0-9])$ ]]; then
-            HOUR=${BASH_REMATCH[1]}
-            MINUTE=${BASH_REMATCH[2]}
+            MINUTE=$(echo "$time_str" | cut -d: -f2)
+            HOUR=$(echo "$time_str" | cut -d: -f1)
             echo "$MINUTE $HOUR * * * appuser source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
             echo "  - Tarefa cron adicionada para: $time_str"
         else

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Adiciona um usuário não root non-root
+RUN groupadd -g ${PGID} appuser && useradd -u ${PUID} -g appuser -m -s /bin/bash appuser
+
 # Cria a pasta /app/config se não existir
 mkdir -p /app/config/kometa/tssk
 
@@ -49,7 +52,6 @@ fi
 
 chmod 0644 /etc/cron.d/tssk-cron
 
-# --- PASSO 3: Execução Imediata (Opcional) --- #
 # Verifica se a variável RUN_ON_STARTUP está definida como "true" (ignorando maiúsculas/minúsculas)
 if [[ "${RUN_ON_STARTUP,,}" == "true" ]]; then
     echo "Executando o script imediatamente na inicialização (RUN_ON_STARTUP=true)..."
@@ -57,12 +59,8 @@ if [[ "${RUN_ON_STARTUP,,}" == "true" ]]; then
     su -s /bin/bash -c "source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py" appuser 2>&1 | tee -a /var/log/cron.log &
 fi
 
-# --- PASSO 4: Inicia o Cron e o Log --- #
+# ---Inicia o Cron e o Log --- #
 cron -f &
-
-echo "O TSSK está sendo iniciado com a seguinte programação cron:"
-cat /etc/cron.d/tssk-cron
-echo ""
 touch /var/log/cron.log
 chown "${PUID}:${PGID}" /var/log/cron.log
 exec tail -f /var/log/cron.log

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,24 +9,49 @@ cp -r /app/files/* /app/config/
 # Ajustar permissões se necessário
 chown -R "${PUID}:${PGID}" /app
 
-# --- PASSO 1: Cria um arquivo de ambiente para o cron ---
-# Escreve as variáveis necessárias em um arquivo oculto
+# Escreve as variáveis necessárias em um arquivo oculto para que o cron possa acessá-las
 echo "export DOCKER=$DOCKER" > /app/.cron_env
 echo "export PUID=$PUID" >> /app/.cron_env
 echo "export PGID=$PGID" >> /app/.cron_env
+echo "export TZ=$TZ" >> /app/.cron_env # Inclui TZ para o contexto do cron
 
-# Adiciona o cronjob no arquivo do crontab
+# Limpa o arquivo de configuração do cron para evitar duplicações ou entradas antigas
+> /etc/cron.d/tssk-cron
+
+# Define o shell e o usuário para as tarefas cron
 echo "SHELL=/bin/bash" > /etc/cron.d/tssk-cron
 echo "USER=appuser" >> /etc/cron.d/tssk-cron
 
-# --- PASSO 2: Carrega o arquivo de ambiente antes de rodar o comando ---
-# O 'source' garante que as variáveis estejam disponíveis
-echo "$CRON source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
+# Priorizar a nova variável DAILY_TIMES para horários em formato "normal"
+if [ -n "$DAILY_TIMES" ]; then
+    echo "Configurando agendamentos diários a partir de DAILY_TIMES: $DAILY_TIMES"
+    IFS=',' read -ra ADDR <<< "$DAILY_TIMES"
+    for i in "${ADDR[@]}"; do
+        time_str=$(echo "$i" | xargs)
+        if [[ "$time_str" =~ ^([0-1]?[0-9]|2[0-3]):([0-5]?[0-9])$ ]]; then
+            HOUR=${BASH_REMATCH[1]}
+            MINUTE=${BASH_REMATCH[2]}
+            echo "$MINUTE $HOUR * * * source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
+            echo "  - Tarefa cron adicionada para: $time_str"
+        else
+            echo "  - Aviso: Formato de hora inválido '$time_str' em DAILY_TIMES. Esperado HH:MM. Ignorando."
+        fi
+    done
+elif [ -n "$CRON" ]; then
+    echo "Configurando agendamento a partir de CRON: $CRON"
+    echo "$CRON source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
+else
+    echo "Nenhuma variável de ambiente DAILY_TIMES ou CRON foi definida. Nenhuma tarefa cron será agendada."
+    echo "# Nenhuma tarefa cron configurada." >> /etc/cron.d/tssk-cron # Garante que o arquivo não fique vazio
+fi
 
 chmod 0644 /etc/cron.d/tssk-cron
-crontab /etc/cron.d/tssk-cron
-echo "O TSSK está sendo iniciado com a seguinte programação cron : $CRON"
 
-touch /var/log/cron.log
-cron
+cron -f &
+
+echo "O TSSK está sendo iniciado com a seguinte programação cron:"
+cat /etc/cron.d/tssk-cron
+echo ""
+
+touch /var/log/cron.log 
 tail -f /var/log/cron.log

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,7 +23,11 @@ chown "${PUID}:${PGID}" /app/.cron_env # Garante que o appuser possa ler este ar
 echo "SHELL=/bin/bash" >> /etc/cron.d/tssk-cron
 
 # Priorizar a variável HORARIOS_DE_EXECUCAO para horários em formato "normal"
-if [ -n "$HORARIOS_DE_EXECUCAO" ]; then
+if [ -n "$CRON" ]; then
+    echo "Configurando agendamento a partir de CRON: $CRON"
+    echo "$CRON appuser source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
+    
+elif [ -n "$HORARIOS_DE_EXECUCAO" ]; then
     echo "Configurando agendamentos diários a partir de HORARIOS_DE_EXECUCAO: $HORARIOS_DE_EXECUCAO"
     # Remove aspas (simples e duplas) do início e do fim da string para evitar erros de parsing
     CLEANED_TIMES=$(echo "$HORARIOS_DE_EXECUCAO" | sed "s/^'//;s/'$//;s/^\"//;s/\"$//")
@@ -40,9 +44,6 @@ if [ -n "$HORARIOS_DE_EXECUCAO" ]; then
             echo "  - Aviso: Formato de hora inválido '$time_str' em HORARIOS_DE_EXECUCAO. Esperado HH:MM. Ignorando."
         fi
     done
-elif [ -n "$CRON" ]; then
-    echo "Configurando agendamento a partir de CRON: $CRON"
-    echo "$CRON appuser source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
 else
     echo "Nenhuma variável de ambiente HORARIOS_DE_EXECUCAO ou CRON foi definida. Nenhuma tarefa cron será agendada."
     echo "# Nenhuma tarefa cron configurada." >> /etc/cron.d/tssk-cron # Garante que o arquivo não fique vazio

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,6 +12,7 @@ cp -r /app/files/* /app/config/
 
 # Ajusta as permissões do diretório de configuração para que o appuser possa escrever nele.
 chown -R "${PUID}:${PGID}" /app/config
+RUN su - appuser
 
 # Escreve as variáveis necessárias em um arquivo oculto para que o cron possa acessá-las
 echo "export DOCKER=$DOCKER" > /app/.cron_env
@@ -68,6 +69,6 @@ cron -f &
 echo "O TSSK está sendo iniciado com a seguinte programação cron:"
 cat /etc/cron.d/tssk-cron
 echo ""
-
 touch /var/log/cron.log 
+chown "${PUID}:${PGID}" /var/log/cron.log
 exec tail -f /var/log/cron.log

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Verifica se o usuário 'appuser' existe. Se não, encerra com erro.
+if ! id -u appuser >/dev/null 2>&1; then
+    echo "Erro: O usuário 'appuser' não existe na imagem. A imagem Docker precisa ser construída com este usuário."
+    exit 1
+fi
+
 # Cria a pasta /app/config se não existir
 mkdir -p /app/config/kometa/tssk
 
@@ -20,7 +26,6 @@ echo "export TZ=$TZ" >> /app/.cron_env # Inclui TZ para o contexto do cron
 
 # Define o shell e o usuário para as tarefas cron
 echo "SHELL=/bin/bash" >> /etc/cron.d/tssk-cron
-echo "USER=appuser" >> /etc/cron.d/tssk-cron
 
 # Priorizar a nova variável DAILY_TIMES para horários em formato "normal"
 if [ -n "$DAILY_TIMES" ]; then
@@ -34,7 +39,7 @@ if [ -n "$DAILY_TIMES" ]; then
         if [[ "$time_str" =~ ^([0-1]?[0-9]|2[0-3]):([0-5]?[0-9])$ ]]; then
             HOUR=${BASH_REMATCH[1]}
             MINUTE=${BASH_REMATCH[2]}
-            echo "$MINUTE $HOUR * * * source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
+            echo "$MINUTE $HOUR * * * appuser source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
             echo "  - Tarefa cron adicionada para: $time_str"
         else
             echo "  - Aviso: Formato de hora inválido '$time_str' em DAILY_TIMES. Esperado HH:MM. Ignorando."
@@ -42,7 +47,7 @@ if [ -n "$DAILY_TIMES" ]; then
     done
 elif [ -n "$CRON" ]; then
     echo "Configurando agendamento a partir de CRON: $CRON"
-    echo "$CRON source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
+    echo "$CRON appuser source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
 else
     echo "Nenhuma variável de ambiente DAILY_TIMES ou CRON foi definida. Nenhuma tarefa cron será agendada."
     echo "# Nenhuma tarefa cron configurada." >> /etc/cron.d/tssk-cron # Garante que o arquivo não fique vazio

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,37 +22,37 @@ chown "${PUID}:${PGID}" /app/.cron_env # Garante que o appuser possa ler este ar
 # Define o shell e o usuário para as tarefas cron
 echo "SHELL=/bin/bash" >> /etc/cron.d/tssk-cron
 
-# Priorizar a variável CRON para agendamento customizado. Se não for informada, usar HORARIOS_DE_EXECUCAO.
-if [ -n "$CRON" ]; then
-    echo "Configurando agendamento a partir de CRON: $CRON"
-    echo "$CRON appuser source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
-elif [ -n "$HORARIOS_DE_EXECUCAO" ]; then
-    echo "Configurando agendamentos diários a partir de HORARIOS_DE_EXECUCAO: $HORARIOS_DE_EXECUCAO (CRON não foi definido)"
+# Priorizar a variável DAILY_TIMES para horários em formato "normal"
+if [ -n "$DAILY_TIMES" ]; then
+    echo "Configurando agendamentos diários a partir de DAILY_TIMES: $DAILY_TIMES"
     # Remove aspas (simples e duplas) do início e do fim da string para evitar erros de parsing
-    CLEANED_TIMES=$(echo "$HORARIOS_DE_EXECUCAO" | sed "s/^'//;s/'$//;s/^\"//;s/\"$//")
+    CLEANED_TIMES=$(echo "$DAILY_TIMES" | sed "s/^'//;s/'$//;s/^\"//;s/\"$//")
     IFS=',' read -ra ADDR <<< "$CLEANED_TIMES"
     for i in "${ADDR[@]}"; do
         # Remove espaços em branco da string de tempo
         time_str=$(echo "$i" | xargs)
         if [[ "$time_str" =~ ^([0-1]?[0-9]|2[0-3]):([0-5]?[0-9])$ ]]; then
-            MINUTE=$(echo "$time_str" | cut -d: -f2)
-            HOUR=$(echo "$time_str" | cut -d: -f1)
+            HOUR=${BASH_REMATCH[1]}
+            MINUTE=${BASH_REMATCH[2]}
             echo "$MINUTE $HOUR * * * appuser source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
             echo "  - Tarefa cron adicionada para: $time_str"
         else
-            echo "  - Aviso: Formato de hora inválido '$time_str' em HORARIOS_DE_EXECUCAO. Esperado HH:MM. Ignorando."
+            echo "  - Aviso: Formato de hora inválido '$time_str' em DAILY_TIMES. Esperado HH:MM. Ignorando."
         fi
     done
+elif [ -n "$CRON" ]; then
+    echo "Configurando agendamento a partir de CRON: $CRON"
+    echo "$CRON appuser source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
 else
-    echo "Nenhuma variável de ambiente CRON ou HORARIOS_DE_EXECUCAO foi definida. Nenhuma tarefa cron será agendada."
+    echo "Nenhuma variável de ambiente DAILY_TIMES ou CRON foi definida. Nenhuma tarefa cron será agendada."
     echo "# Nenhuma tarefa cron configurada." >> /etc/cron.d/tssk-cron # Garante que o arquivo não fique vazio
 fi
-# ALterar permição do arquivo
+
 chmod 0644 /etc/cron.d/tssk-cron
 
-# Verifica se a variável EXECUTAR_AO_INICIAR está definida como "true" (ignorando maiúsculas/minúsculas)
-if [[ "${EXECUTAR_AO_INICIAR,,}" == "true" ]]; then
-    echo "Executando o script imediatamente na inicialização (EXECUTAR_AO_INICIAR=true)..."
+# Verifica se a variável RUN_ON_STARTUP está definida como "true" (ignorando maiúsculas/minúsculas)
+if [[ "${RUN_ON_STARTUP,,}" == "true" ]]; then
+    echo "Executando o script imediatamente na inicialização (RUN_ON_STARTUP=true)..."
     # Executa como 'appuser' para manter a consistência de permissões com os trabalhos do cron.
     su -s /bin/bash -c "source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py" appuser 2>&1 | tee -a /var/log/cron.log &
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Adiciona um usuário não root non-root
-RUN groupadd -g ${PGID} appuser && useradd -u ${PUID} -g appuser -m -s /bin/bash appuser
-
 # Cria a pasta /app/config se não existir
 mkdir -p /app/config/kometa/tssk
 
@@ -24,11 +22,14 @@ chown "${PUID}:${PGID}" /app/.cron_env # Garante que o appuser possa ler este ar
 # Define o shell e o usuário para as tarefas cron
 echo "SHELL=/bin/bash" >> /etc/cron.d/tssk-cron
 
-# Priorizar a variável DAILY_TIMES para horários em formato "normal"
-if [ -n "$DAILY_TIMES" ]; then
-    echo "Configurando agendamentos diários a partir de DAILY_TIMES: $DAILY_TIMES"
+# Priorizar a variável CRON para agendamento customizado. Se não for informada, usar HORARIOS_DE_EXECUCAO.
+if [ -n "$CRON" ]; then
+    echo "Configurando agendamento a partir de CRON: $CRON"
+    echo "$CRON appuser source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
+elif [ -n "$HORARIOS_DE_EXECUCAO" ]; then
+    echo "Configurando agendamentos diários a partir de HORARIOS_DE_EXECUCAO: $HORARIOS_DE_EXECUCAO (CRON não foi definido)"
     # Remove aspas (simples e duplas) do início e do fim da string para evitar erros de parsing
-    CLEANED_TIMES=$(echo "$DAILY_TIMES" | sed "s/^'//;s/'$//;s/^\"//;s/\"$//")
+    CLEANED_TIMES=$(echo "$HORARIOS_DE_EXECUCAO" | sed "s/^'//;s/'$//;s/^\"//;s/\"$//")
     IFS=',' read -ra ADDR <<< "$CLEANED_TIMES"
     for i in "${ADDR[@]}"; do
         # Remove espaços em branco da string de tempo
@@ -39,22 +40,19 @@ if [ -n "$DAILY_TIMES" ]; then
             echo "$MINUTE $HOUR * * * appuser source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
             echo "  - Tarefa cron adicionada para: $time_str"
         else
-            echo "  - Aviso: Formato de hora inválido '$time_str' em DAILY_TIMES. Esperado HH:MM. Ignorando."
+            echo "  - Aviso: Formato de hora inválido '$time_str' em HORARIOS_DE_EXECUCAO. Esperado HH:MM. Ignorando."
         fi
     done
-elif [ -n "$CRON" ]; then
-    echo "Configurando agendamento a partir de CRON: $CRON"
-    echo "$CRON appuser source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" >> /etc/cron.d/tssk-cron
 else
-    echo "Nenhuma variável de ambiente DAILY_TIMES ou CRON foi definida. Nenhuma tarefa cron será agendada."
+    echo "Nenhuma variável de ambiente CRON ou HORARIOS_DE_EXECUCAO foi definida. Nenhuma tarefa cron será agendada."
     echo "# Nenhuma tarefa cron configurada." >> /etc/cron.d/tssk-cron # Garante que o arquivo não fique vazio
 fi
-
+# ALterar permição do arquivo
 chmod 0644 /etc/cron.d/tssk-cron
 
-# Verifica se a variável RUN_ON_STARTUP está definida como "true" (ignorando maiúsculas/minúsculas)
-if [[ "${RUN_ON_STARTUP,,}" == "true" ]]; then
-    echo "Executando o script imediatamente na inicialização (RUN_ON_STARTUP=true)..."
+# Verifica se a variável EXECUTAR_AO_INICIAR está definida como "true" (ignorando maiúsculas/minúsculas)
+if [[ "${EXECUTAR_AO_INICIAR,,}" == "true" ]]; then
+    echo "Executando o script imediatamente na inicialização (EXECUTAR_AO_INICIAR=true)..."
     # Executa como 'appuser' para manter a consistência de permissões com os trabalhos do cron.
     su -s /bin/bash -c "source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py" appuser 2>&1 | tee -a /var/log/cron.log &
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -50,15 +50,16 @@ fi
 
 chmod 0644 /etc/cron.d/tssk-cron
 
-# Verifica se a variável EXECUTAR_AO_INICIAR está definida como "true" (ignorando maiúsculas/minúsculas)
-if [[ "${EXECUTAR_AO_INICIAR,,}" == "true" ]]; then
-    echo "Executando o script imediatamente na inicialização (EXECUTAR_AO_INICIAR=true)..."
-    # Executa como 'appuser' para manter a consistência de permissões com os trabalhos do cron.
-    su -s /bin/bash -c "source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py" appuser 2>&1 | tee -a /var/log/cron.log &
-fi
-
-# ---Inicia o Cron e o Log --- #
-cron -f &
+# Alterações de permissão para o usuário do cron
 touch /var/log/cron.log
 chown "${PUID}:${PGID}" /var/log/cron.log
+
+# Verifica se a variável EXECUTAR_AO_INICIAR está definida como "true" (ignora maiúsculas/minúsculas)
+if [[ "${EXECUTAR_AO_INICIAR,,}" == "true" ]]; then
+    echo "Executando o script imediatamente na inicialização (EXECUTAR_AO_INICIAR=true)..."
+    su -s /bin/bash -c "source /app/.cron_env && cd /app && /usr/local/bin/python TSSK.py 2>&1 | tee -a /var/log/cron.log" appuser &
+fi
+
+# --- Inicia o Cron e o Log --- #
+cron -f &
 exec tail -f /var/log/cron.log

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -52,6 +52,7 @@ else
 fi
 
 chmod 0644 /etc/cron.d/tssk-cron
+crontab /etc/cron.d/tssk-cron
 
 # --- PASSO 3: Execução Imediata (Opcional) --- #
 # Verifica se a variável RUN_ON_STARTUP está definida como "true" (ignorando maiúsculas/minúsculas)


### PR DESCRIPTION
- Inserida a possibilidade de configurar o script para rodar em diversos horários, sem a necessidade de entender de tradução para CRON, os horários devem ser informados separados por virgula Ex.: 08:00,09:00. Útil para quem tem uma biblioteca muito dinâmcia, onde itens são baixados para o Plex constantemente.
- Inserida a possibilidade da execução imediata do script ao inicicar o docker, as próximas execuções seguem de acordo com o CRON ou horário configurado. 